### PR TITLE
Fix typo in homepage feature overview

### DIFF
--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -26,7 +26,7 @@ const FeatureList: FeatureItem[] = [
     ),
   },
   {
-    title: 'Opionated',
+    title: 'Opinionated',
     Svg: UndrawInformedDecision,
     description: (
       <>


### PR DESCRIPTION
Fixes a small typo in the Feature Overview, where "Opinionated" was likely misspellt.

Related Issue: #24 