### PR TITLE
First pass at 4.19 release notes

### DIFF
--- a/blog/2025/05-16-okd-4.19-release-notes.md
+++ b/blog/2025/05-16-okd-4.19-release-notes.md
@@ -1,0 +1,130 @@
+---
+title: OKD 4.19 Release Notes
+authors: ["Prashanth684"]
+date: 2025-05-16
+---
+
+## Release Notes: 4.19.0-okd-scos.0
+
+This release includes updates across various components, introducing new features, managing feature gates, and resolving numerous bugs to enhance stability and functionality. [4.19.0-okd-scos.0](https://amd64.origin.releases.ci.openshift.org/releasestream/4-scos-stable/release/4.19.0-okd-scos.0) is the source of this information.
+
+### New Features
+
+Several new capabilities and improvements have been introduced in this release:
+- Support for ServiceAccountTokenNodeBinding has been enabled via a feature gate.
+- The OLMv1 Single/OwnNamespace feature is now available behind a feature flag.
+- MachineConfigNodes (MCN) API has been updated to V1 with corresponding CRDs deployed.
+- The CPMSMachineNamePrefix feature gate has been promoted to the default feature set.
+- The GatewayAPIController feature gate has been enabled in the Default featureset and its implementation includes Validating Admission Policy for Gateway API CRDs. GRPC conformance tests   have also been added for Gateway API. This feature is NOT supported for OKD because the Openshift service mesh operator, which this feature depends on, is not available as a community operator.
+- MAPI to CAPI migration has been added as a TechPreview feature.
+- DualReplica minimum counts have been added, and the feature has been dropped to DevPreview to enable separation of conflicting enum values.
+- The RouteExternalCertificate feature gate has been promoted to the default feature set with added E2E tests.
+- A Featuregate for the ConsolePlugin ContentSecurityPolicy API has been lifted.
+- MetricsCollectionProfiles has reached GA status.
+- Configuration for external OIDC now supports adding uid and extra claim mappings.
+- The OnClusterBuild featuregate has been promoted to GA.
+- Support for SEV_SNP and TDX confidential instance type selection on GCP has been added.
+- SELinuxMount and SELinuxChangePolicy have been added to DevPreview.
+- The infrastructure object now includes service endpoints and a feature flag.
+- An annotation for validated SCC type has been added.
+- Configuration for vSphere multi disk thinProvisioned has been added.
+- API Updates for GCP Custom API Endpoints have been added.
+- The MarketType field has been added to AwsMachineProviderConfig and validation for this field has been added.
+- UserDefinedNetworks (UDN) has been graduated to GA with associated test improvements.
+- The ClusterVersionOperator API and manifests have been added, including a controller.
+- The HighlyAvailableArbiter control plane topology has been added as a feature for techpreview, with support for changing the minimum for arbiter HA deployments.
+- The KMSEncryptionProvider Feature Gate has been introduced, with support for KMSv2 encryption for ARO HCP using MIv3 and related configuration options.
+- The additionalRoutingCapabilities gate has been promoted in the ClusterNetworkOperator API.
+- Support for vSphere host and vm group based zonal has been added.
+- A MachineNamePrefix field for CPMS has been feature-gated with its feature gate also added.
+- vSphere multi disk support has been added, including provisioning mode for data disks.
+- An initial Monitoring CRD api has been added.
+- The Insights runtime extractor feature has been moved to GA.
+- A new config option for storing Insights archives to persistent volume has been introduced.
+- Insight Operator entitlements for multi arch clusters have been enabled.
+- A liveness probe has been added to the Insights extractor container.
+- The LokiStack gatherer has been added to Insights.
+- CNI subdirectory chaining for composable CNI chaining is available.
+- The nodeslicecontroller has been added to the dockerfile for multus-whereabouts-ipam-cni.
+- The console has added numerous UI/UX improvements including PatternFly 6 updates, features like deleting IDPs, improved helm form in admin perspective, adding a default storage class action, guided tours in admin perspective, add-card item alignment fixes, conversion of HTML elements to PatternFly components, adding dark theme feedback graphic, adding a Getting started section to the project overview page, adding support for extensibility in SnapshotClass and StorageClass pages, adding a favoriting page in the Admin perspective, exposing Topology components to the dynamic plugin SDK, adding support for a Virtualization Engine subscription filter on OperatorHub, adding dev perspective nav options to the admin perspective, adding conditional CSP headers support, adding a Dynamic Plugins nav item, adding telemetry for OLS Import to Console, and adding a customData field to the HorizontalNav component.
+- The monitoring-plugin has been updated with PF-6 migration, improved metrics typeahead, label typeahead, plugin proxy for Perses, and the ability to embed Perses Dashboards.
+- Etcd now has a configurable option for hardware-related timeout delay.
+- GCP PD CSI Driver includes an Attach Limit for Hyperdisk + Gen4 VMs and has been rebased to upstream v1.17.4.
+- The GCP PD CSI Driver Operator can enable VolumeAttributesClass and add custom endpoint args from infrastructure.
+- HyperShift now supports adding a control plane pull secret reference, adding proxy trustedCA to ignition config, testing Azure KMS, capacity reservation in NodePool API, passing featuregates to ocm/oapi, enabling MIv3 for Ingress, configuring KAS goaway-chance, overriding the karpenter image, consuming the KubeAPIServerDNSName API, enabling ppc64le builds, syncing the OpenStack CA cert, limiting CAPI CRD installation on HO, annotating AWSEndpointServices, setting default AWS expirationDate tag, running the kas-bootstrap binary for cpov2, disabling the cluster capabilities flag, enabling MIv3 for Azure file CSI driver, enabling MIv3 for CAPZ, adding e2e tests for image registry capability, adding the konnectivity-proxy sidecar to openshift-oauth-apiserver, checking individual catalog image availability, handling multiple mirror entries, rolling out cpov2 workloads on configmap/secret changes, enabling MIv3 for CNO/CNCC on managed Azure, leveraging ORC to manage the release image on OpenStack, rootless containerized builds, enabling linters, allowing autonode to run upstream karpenter core e2e tests, adding a flag for etcd storage size, auto-approving Karpenter serving CSRs, and providing AWS permission documentation.
+- Machine API Operator supports updating GCP CredentialsRequest, e2e tests for vSphere multi network and Data Disk features, AMD SEV_SNP and TDX confidential computing machines on GCP, adding image/read permissions, adding vSphere check for max networks, adding Azure permissions.
+- vSphere Problem Detector supports host groups.
+- Various tests have been updated or added to support new features and platforms, including OLMv1 preflight permissions checks, MCN V1 API tests, OLMv1 catalogd API endpoint tests, Gateway API tests, testing ratcheting validations, detecting concurrent installer/static pods, platform type external support, and tests for the ImageStreamImportMode feature gate.
+
+### Feature Gates
+- CPMSMachineNamePrefix has been promoted to the default feature set.
+- GatewayAPIController has been enabled in the Default featureset. Its implementation includes Validating Admission Policy and is tied to the cluster-ingress-operator. (NOT applicable for OKD)
+- DualReplica minimum count has been added, separation of conflicting enum values enabled, and the feature dropped to DevPreview.
+- RouteExternalCertificate has been promoted to the default feature set.
+- ConsolePlugin ContentSecurityPolicy API feature gate has been lifted.
+- OnClusterBuild has been promoted to GA.
+- GatewayAPI has been re-enabled in the Default featureset and promoted to Tech Preview.
+- VSphereStaticIPs feature gate has been removed.
+- NewOLMPreflightPermissionCheck feature flag has been added and is watched by the cluster-olm-operator.
+- VSphereControlPlaneMachineSet feature gate has been removed.
+- KMS encryption is FeatureGate(d) and the KMSEncryptionProvider Feature Gate has been added.
+- DualReplica featuregate has been added.
+- SELinuxMount and SELinuxChangePolicy have been added to DevPreview.
+- The catalogd metas web api is behind a featuregate.
+- A Feature Gate AND on NetworkLoadBalancer CEL has been added.
+- HighlyAvailableArbiter control plane topology is a feature for techpreview.
+- Persistent Ips feature gate has graduated to GA.
+- MachineNamePrefix field for CPMS is feature-gated with its feature gate also added.
+- CSIDriverSharedResource feature gate has been removed.
+- The ShortCertRotation feature gate has been added and is used to issue short lived certificates in the cluster-kube-apiserver-operator and service-ca-operator.
+- The UserDefinedNetworks feature gate has graduated to GA.
+- The additionalRoutingCapabilities gate has been promoted.
+- The ImageRegistryCapability has been introduced behind a feature gate in HyperShift and tested.
+- The Dynamic Configuration Manager feature gate has follow-up work to be enabled.
+- The cluster-olm-operator watches for the APIV1MetasHandler feature gate.
+- The cluster-olm-operator watches for permissions preflight feature gate.
+- The service-ca-operator does not check featuregates on the operand.
+
+### Other Feature Gates Enabled by Default:
+- ConsolePluginContentSecurityPolicy: Status is Enabled in the Default set. The featuregate was lifted for this API. This gate was added to the console-operator.
+- OpenShiftPodSecurityAdmission: Status is Enabled in the Default set.
+- ClusterVersionOperatorConfiguration: Status is Enabled (New) in the Default set.
+- DyanmicServiceEndpointIBMCloud: Status is Enabled (New) in the Default set.
+- GCPCustomAPIEndpoints: Status is Enabled (New) in the Default set. There were API updates for GCP Custom API Endpoints.
+- NewOLMCatalogdAPIV1Metas: Status is Enabled (New) in the Default set. The featuregate for catalogd metas web API was added and is watched for.
+- NewOLMOwnSingleNamespace: Status is Enabled (New) in the Default set. A feature flag was added for OLMv1 Single/OwnNamespace.
+- NewOLMPreflightPermissionChecks: Status is Enabled (New) in the Default set. A feature flag for this was added and is watched for.
+- SigstoreImageVerificationPKI: Status is Enabled (New) in the Default set. A PKI field was added to the image API.
+- VSphereConfigurableMaxAllowedBlockVolumesPerNode: Status is Enabled (New) in the Default set. The MaxAllowedBlockVolumesPerNode field was added to the VSphereCSIDriverConfigSpec.
+- VSphereMultiDisk: Status is Enabled (New) in the Default set. Support for vSphere multi disk was added.
+- ClusterAPIInstallIBMCloud: Status changed from Disabled to Enabled in this set. This feature flag was added to Tech Preview.
+- MachineAPIMigration: Status changed from Disabled to Enabled in this set. MAPI to CAPI migration was added to TechPreview.
+
+### Bug Fixes
+Numerous bugs have been addressed in this release across various components:
+- Validation for the marketType field in aws-cluster-api-controllers has been added.
+- Fixed issues using 127.0.0.1 for healtz http-endpoints, corrected ASH driver inject env config, and fixed PodDisruptionBudget name for openstack-manila.
+- Azure Stack Hub volume detach failure has been fixed.
+- Panic issues in Azure Stack related to GetZoneByNodeName and when the informer receives cache.DeletedFinalStateUnknown have been fixed.
+- GovCloud Config has been fixed.
+- Cross-subscription snapshot deletion is now allowed in azure-file-csi-driver. CVEs related to golang.org/x/crypto and golang.org/x/net have been addressed.
+- Fixes in the CLI include addressing rpmdiff permissions, using ProxyFromEnvironment for HTTP transport, adjusting the impact summary for Failing=Unknown, populating RESTConfig, bumping glog and golang.org/x/net/crypto dependencies for fixes, ensuring monitor doesn't exit for temp API disconnect, fixing the oc adm node-image create –pxe command, parsing node logs with HTML headers, and obfuscating sensitive data in Proxy resource inspection.
+- Logo alignment in Webkit has been fixed in cluster-authentication-operator. Duplicate OAuth client creation is avoided. An issue updating the starter path for mom integration has been fixed. Etcd readiness checks are excluded from /readyz.
+- Broken ControlPlaneMachineSet integration tests have been fixed. A spelling error in the FeatureGate NewOLMCatalogdAPIV1Metas has been fixed. A typo in insightsDataGather has been fixed. A race in tests using CRD patches has been fixed. Handling of validations requiring multiple feature gates has been fixed. Missing CSP directives have been added. StaticPodOperatorStatus validation for downgrades and concurrent node rollouts has been fixed. Insights types duration validation has been fixed. An example format validation has been added. Unused MAPO fields have been deprecated. Reverted Disable ResilientWatchCacheInitialization.
+- IBM Public Cloud DNS Provider Update Logic has been fixed, along with IBMCloud DNS Propagation Issues in E2E tests. A test is skipped when a specific feature gate is enabled. Single Watch on GWAPI CRD issue has been fixed.
+- Dev cert rotation has been reverted in cluster-kube-apiserver-operator. Etcd endpoints are now checked by targetconfigcontroller. Metrics burn rate calculations and selectors have been adjusted or fixed. Skipping cert generation when networkConfig.status.ServiceNetwork is nil has been fixed. Reverted Disable ResilientWatchCacheInitialization.
+- The gracefully shutdown of the KSVM pod has been fixed.
+- Error handling on port collision in CVO has been improved. A few tests failing on Non-AMD64 machines have been fixed. Unknown USC insights are dropped after a grace period. The preconditions code has been simplified.
+- Numerous console UI/UX and functional bugs have been fixed, including list header wrapping, http context/client handling, quick create button data-quickstart-id, critical alerts section collapsing, runtime errors on MachineConfigPools, switch animation regressions, ACM hiding switcher, favorites button name, listpageheader rendering, tab underline missing, notification drawer spacing, withHandlePromise HOC deprecation, quick start action spacing, operator appearing twice, breadcrumb spacing, web terminal initialize form style, quickstart highlighting, base CSS removal/conversion, VirtualizedTable and ListPageFilter deprecation, OLM CSV empty state link, helpText usage, add card item alignment, ErrorBoundary modal link, DualReplica validation hack, fetching taskRuns by UID, catalog view cleanup, PF6 bug fixes, deployment editing from private git, co-resource-icon clipping, notification drawer keyboard navigation, flaking update-modal tests, orphaned CSS class removal, PDB example YAML missing field, Error state component groups, Developer Catalog renaming, Favorites e2e tests, secret form base64 decoding, typo on tour page, helm chart repository name, SnapshotClass/StorageClass extensibility, plugin type-only warnings, react-helmet/react-measure migration, pipeline ci tests disabling, plugin-api-changed label, getting started alert, perspective merge tests, react-modal/react-tagsinput updates, init containers readiness count, notification drawer overlap, static plugin barrel file references, CaptureTelemetry hooks, flaky Loading tests, admin perspective guided tour disabling, Access review table sort, types/react update, getting started resources content, Node Logs toolbar layout, Loading replacement, favorites icon hover effect, LogViewer theme setting, namespace persistence on perspective switch, secret form drag and drop, logoutOpenShift call removal, NodeLogs Selects closing, missing patternfly styles, monaco theming/sidebar logic, Banner replacement, ODC Project details breadcrumbs, resource list page name filter alignment, VolumeSnapshots not displayed, ResourceLog checkbox replacement, ts-ignore removal, Checkbox filter replacement, monitoring topic update, original path retention on perspective detection, monaco/YAML language server update, subscription values display, Jobs createdTime, CLI links sorting, bottom notifications alignment, notification drawer close button error, Timestamp component, unused static plugin modules, edit resource limit margins, CSRs not loading without permissions, async package upgrade, bold text/link underline issues, dropdown menu overflow, contextId for plugin tabs, OLM operator uninstall message linkify, Observe section display, textarea horizontal expansion, Topology sidebar alert storage, Demo Plugin tab URL, Command Line Terminal tab background color, basic authentication secret type, runtime errors for completed version, QueryBrowser tooltip styles, edit upstream config layout, deployment pod update on imageStream change, Bootstrap radio/checkbox alignment, QuickStart layout, guided tour popover overlap, Edit button bolding, cypress config update, bridge flag for CSP features, CSV details plugin name, Pipeline Repository overview page close button, Topology component exposure, catalog card label alignment, YAMLs directory case sensitivity, Search filter dropdown label i18n, broken codeRefs, CSP headers refresh popover, dev-console cypress test update, plugin name parsing variable, dependency assets copying, ns dropdown UI with web terminal, SourceSecretForm/BasicAuthSubform tech debt, create a Project button, GQL query payload size, non-General User Preference navigation, openshift Authenticate func user token, catalog operator installation parameters, telemetry events OpenShift release version preference, web terminal test failures, errors appending via string, external link icons, BuildSpec details heading font size, capitalization fix for Lightspeed, i18n upload/download, Font Awesome icon alignment, Serverless function test no response, Post TypeScript upgrade changes, helm CI failures, TypeScript upgrade, GQL introspection disabling, code removal, axe-core/cypress-axe upgrade, search tool error, PopupKebabMenu/ClusterConfigurationDropdownField removal, operator installation with + in version name, missing PDB violated translation, Number input focus layout, AlertsRulesDetailPage usage, guessModuleFilePath warnings, channel/version dropdown collapse, webpack 5 upgrade, check-resolution parallel run, Init:0/1 pod status, window.windowErrors saving, ConsolePlugins list display, backend service details runtime error, Function Import error, default StorageClass for ServerlessFunction pipelineVolumeClaimTemplate, Save button enablement in Console plugin enablement, ImagePullSecret duplication, Shipwright build empty params filtering.
+- The managed-by-label populated with an invalid value has been fixed in external-provisioner. CVEs related to golang.org/x/net/crypto have been addressed.
+- Etcd ensure cluster id changes during force-new-cluster, and a compaction induce latency issue has been fixed.
+- Volume unpublish and attachment through reboots has been ensured for kubevirt-csi-driver.
+- A temporary pin on the FRR version has been applied in metallb-frr to a known working rpm.
+- Monitoring plugin fixes include updates to avoid overriding console routes, table scroll/column alignment, performance improvements for incidents page, resetting orthogonal selections, not breaking if cluster doesn’t exist, filtering by cluster name, showing column headings, fixing states filter in aggregated row, clearing old queries, fixing silence alerts data form, re-adding CSV button, allowing refresh interval to be off, removing deleted image dependency, Export as CSV, not showing metrics links in acm perspective, updating datasource on csrf token changes, adding mui/material dependency, fixing typo in predefined metrics, fixing virtualization perses extension point, filter dropdowns, alerts timestamps cutoff, incidents page filters, incidents page loading state, net/http vulnerability, tooltip in row details, fixing incidents filter issues with severities and long standing, incidents dark theme, syncing alert chart to main filter, hotfix for filter requirements, alerting refactor, virtualization perspective routes, potentially undefined variable access, incident chart colors, incidents filter logic/sync, syncing alerts chart/incidents table with days filter, sorting chart bars, reverting reset all filters button, fixing gap in incident charts, using pf v5 variables/table, fixing dev perspective alert URL namespace, incidents page date style, hideshow graph button update, incidents page reset filters, fixing admin console alert detail graph, fixing button spacing on silence form, fixing bounds on bar chart, fixing inverted dropdown toggle, allowing editing of the until field on the silence edit page, fixing feature flagged DX, fixing expanded row rendering, upgrading incidents dropdown, updating incidents charts cursor, removing extra copy.
+- Issues writing network status annotation on CNI ADD have been tolerated in multus-cni. Empty CNI result is properly structured. Getpodcontext cache miss has been fixed.
+- Entrypoint issues have been fixed for multus-whereabouts-ipam-cni, including for new SCOS builds.
+- An error event has been added for failed ingress to route conversion in route-controller-manager.
+- Drop nil metrics during elide transform and capture metric for same has been fixed in telemeter, along with checking nil metric in elide label.
+- Numerous test fixes have been implemented, including increasing timeouts, bumping limits, skipping tests, fixing node selection in MCN tests, fixing MCN tests for two-node clusters, preventing tests using unschedulable nodes, fixing default cert issuer name in RouteExternalCertificate tests, ensuring Git Clone does not run privileged, fixing failed arbiter tests, removing skipped annotation for metal ipv6, adding limit exceptions for Istio, adding cleanup to MCN test, removing CRD schema check, fixing broken intervals charts, fixing egress firewall tests URLs, fixing CBOR data decoding in etcd tests, fixing IPsec tests, validating binary extraction, failing test when operator degrades, using payload pullspec for image info, using non-fake boot image, relying on unstructured for update status, checking load balancer healthcheck port/path, allowing overriding extension binary, re-enabling AWS for router HTTP/2 test, displaying etcd bootstrap event, fixing network name change compatibility, increasing timeouts for live migration, addressing malformed configmap post-test, increasing UDN probe timeouts, adding exceptions outside upgraded window, adding Readiness Probe to Router Status Tests, adding error check for failed cleanup, fixing live migration tests detecting dualstack, extending kubeconfig tests, fixing IPv6 handling in router tests, fixing live migration tests, UDN tests waiting for SCC annotation, fixing auditLogAnalyzer flake error, fixing nmstate deployment failures, showing resources updated too often in auditloganalyzer, skipping OperatorHubSourceError metric checking, adding test case for checking EgressFirewall DNS names, fixing network segmentation eventual consistency, increasing KAPI server timeout, using max time for netpol pods curl requests, moving initialization of OC.
+- Datastore check messages have been improved in vsphere-problem-detector.
+


### PR DESCRIPTION
Generated with help from NotebookLLM and the 4.19 release controller page: https://amd64.origin.releases.ci.openshift.org/releasestream/4-scos-stable/release/4.19.0-okd-scos.0