### PR TITLE
Generated 4.21 release notes

### DIFF
--- a/blog/2026/01-26-okd-4.21-release-notes.md
+++ b/blog/2026/01-26-okd-4.21-release-notes.md
@@ -6,17 +6,100 @@ date: 2026-01-26
 
 ## Release Notes: 4.21.0-okd-scos.0
 
-This release includes updates across various components, introducing new features, managing feature gates, and resolving numerous bugs to enhance stability and functionality. [4.21.0-okd-scos.0](https://amd64.origin.releases.ci.openshift.org/releasestream/4-scos-stable/release/4.21.0-okd-scos.0) is the source of this information.
+This release includes updates across various components, introducing new features, managing feature gates, and resolving numerous bugs to enhance stability and functionality. [4.21.0-okd-scos.0](https://amd64.origin.releases.ci.openshift.org/releasestream/4-scos-stable/release/4.21.0-okd-scos.0) is the source of this information. Key highlights include the promotion of Dynamic Resource Allocation (DRA) to General Availability, the adoption of SCOS as the standard base operating system, and a shift toward a more modular testing and monitoring architecture.
+
+## Origin Community Distribution (OKD) Specifics
 
 ### Platform and Installer Updates
 
-*   **SCOS is Now the Standard (OKD-237):** The installer has been updated to exclusively use SCOS (SIG-CoreOS) as the base operating system. All references to the previous Fedora CoreOS (FCOS) have been removed.
-*   **Default Container Runtime Changed to `crun` on Upgrade (OKD-294):** For clusters upgrading to version 4.20, the default container runtime will now be `crun`. The previous override that retained `runc` during upgrades has been removed to align with the new default. User-defined runtime configurations will be preserved.
+* **SCOS as Standard:** The installer now exclusively uses SCOS (SIG-CoreOS) as the base operating system. All references to Fedora CoreOS (FCOS) have been removed.
+* **Default Runtime Change:** Clusters upgrading to version 4.20 and beyond will now use `crun` as the default container runtime. User-defined runtime configurations are preserved during this transition.
+* **Secure Boot for vSphere:** Secure Boot is now enabled by default for OKD deployments on vSphere.
 
-### Virtualization Enhancements
+---
 
-*   **Secure Boot Enabled for vSphere (OKD-279):** Secure Boot is now enabled by default for OKD deployments on vSphere, enhancing the security posture of virtualized clusters.
+## Node and Workloads
 
-### Bare Metal Provisioning (Ironic & Metal3)
+### Dynamic Resource Allocation (DRA) - GA
 
-*   **Component Stability Fixes (OKD-306, OKD-297, OKD-283, OKD-304, OKD-295):** A series of improvements have been made to enhance the reliability of bare metal deployments. These updates resolve issues that caused `ironic-proxy` and `metal3` pods to crash, fix broken `ironic-agent-image` and `ironic-image` containers, and correct a missing `pyinotify` module that previously caused `metal3` deployment failures.
+DRA has been promoted to General Availability. This feature provides a more flexible framework for managing hardware resources like GPUs.
+
+* The `v1` DRA API is now the standard; alpha/beta APIs have been removed.
+* **Prioritized Alternatives:** Pods can now request a prioritized list of device options, allowing for fallback choices if primary resources are unavailable.
+
+### Security and Resource Management
+
+* **User Namespaces (GA):** Linux user namespaces are now GA, providing enhanced isolation by remapping user and group IDs inside containers.
+* **Automatic System Resource Reservation:** The `autoSizingReserved` feature in `KubeletConfig` is now enabled by default, automatically calculating optimal CPU and memory reservations for system components.
+* **Image Verification (GA):** The default `openshift` ClusterImagePolicy and `SigstoreImageVerificationPKI` are now GA, allowing clusters to validate release payloads and use custom PKI for image signatures out of the box.
+
+---
+
+## Storage
+
+### Volume Management
+
+* **VolumeAttributesClass (VAC) - GA:** Users can now modify volume attributes like IOPS and throughput after creation for supported CSI drivers.
+* **Azure File Volume Cloning (GA):** Supports cloning for both SMB and NFS protocols.
+* **VolumeGroup Snapshots:** The API has been updated to `v1beta2`.
+
+### Platform Compatibility
+
+* **vSphere Bare-Metal Support (Tech Preview):** The vSphere CSI driver now automatically disables itself on bare-metal nodes within hybrid vSphere clusters to prevent degraded states.
+* **oVirt Removal:** The oVirt CSI driver and operator have been removed as the platform is no longer supported.
+
+---
+
+## Networking
+
+### Core Networking Enhancements
+
+* **Static IP/MAC for VMs (GA):** Assigning static IP and MAC addresses to Virtual Machines on secondary Layer 2 User-Defined Networks (UDNs) is now GA. This includes active MAC conflict detection to prevent network collisions.
+* **IPv6/Dual-Stack Installation:** A new feature gate enables IPv6 and dual-stack configurations during initial cluster setup.
+
+### Ingress and DNS
+
+* **Label Propagation:** Labels can now be synchronized from an Ingress resource to its generated Route using the `route.openshift.io/reconcile-labels: "true"` annotation.
+* **Optional VIPs:** Users can now disable internal DNS records when utilizing external load balancers that manage their own DNS.
+
+---
+
+## Installer and Cloud Provider Updates
+
+### AWS Improvements
+
+* **EC2 Dedicated Hosts:** OpenShift now supports deployment on AWS Dedicated Hosts for both platform-provisioned and BYOH (Bring Your Own Host) scenarios.
+* **Confidential VMs:** Support for AMD SEV-SNP confidential computing is now available for both control plane and compute nodes.
+
+### GCP and Azure
+
+* **GCP Spot VMs:** Worker nodes can now be created using GCP Spot VMs by setting `provisioningModel: "Spot"` in the `GCPMachineProviderSpec`.
+* **Azure Marketplace Images:** The installer now defaults to using pre-existing RHCOS images from the Azure Marketplace to speed up deployment.
+
+---
+
+## Management and Observability
+
+### Console and UI
+
+* **Developer Perspective Deprecation:** Monitoring views (Dashboards, Targets) have been integrated into the Admin Perspective under the "Observe" section.
+* **OLMv1 Integration:** The Console now supports the new OLMv1 catalog (Tech Preview), including channel and version selection for extensions.
+
+### Monitoring and Diagnostics
+
+* **CRD-Based Configuration:** A new feature-gated capability allows configuring the monitoring stack via CRDs instead of ConfigMaps, providing faster API validation.
+* **`must-gather` Improvements:** The tool now automatically inspects its own temporary namespace if a pod fails, aiding in self-diagnostics.
+* **Unified Service Mesh Diagnostics:** `istio-must-gather` has been consolidated into the primary OpenShift `must-gather` tool.
+
+---
+
+## Over the Air (OTA) Updates
+
+* **Upgrade Recommendations:** The `oc adm upgrade recommend` command is now GA and enabled by default.
+* **Upgrade Stability:** Improved accuracy for the `Progressing` status, ensuring transient events like node reboots do not trigger false state changes during cluster updates.
+
+---
+
+## Known Issues
+
+* **CustomNoUpgrade:** Enabling the `CustomNoUpgrade` feature gate may cause the `network` and `olm` Cluster Operators to enter a degraded state.

--- a/blog/2026/01-26-okd-4.21-release-notes.md
+++ b/blog/2026/01-26-okd-4.21-release-notes.md
@@ -8,9 +8,6 @@ date: 2026-01-26
 
 This release includes updates across various components, introducing new features, managing feature gates, and resolving numerous bugs to enhance stability and functionality. [4.21.0-okd-scos.0](https://amd64.origin.releases.ci.openshift.org/releasestream/4-scos-stable/release/4.21.0-okd-scos.0) is the source of this information.
 
-### New Features
-Here is a summary of the recent updates to the Origin Community Distribution of Kubernetes (OKD).
-
 ### Platform and Installer Updates
 
 *   **SCOS is Now the Standard (OKD-237):** The installer has been updated to exclusively use SCOS (SIG-CoreOS) as the base operating system. All references to the previous Fedora CoreOS (FCOS) have been removed.

--- a/blog/2026/01-26-okd-4.21-release-notes.md
+++ b/blog/2026/01-26-okd-4.21-release-notes.md
@@ -1,0 +1,25 @@
+---
+title: OKD 4.21 Release Notes
+authors: ["Prashanth684"]
+date: 2026-01-26
+---
+
+## Release Notes: 4.21.0-okd-scos.0
+
+This release includes updates across various components, introducing new features, managing feature gates, and resolving numerous bugs to enhance stability and functionality. [4.21.0-okd-scos.0](https://amd64.origin.releases.ci.openshift.org/releasestream/4-scos-stable/release/4.21.0-okd-scos.0) is the source of this information.
+
+### New Features
+Here is a summary of the recent updates to the Origin Community Distribution of Kubernetes (OKD).
+
+### Platform and Installer Updates
+
+*   **SCOS is Now the Standard (OKD-237):** The installer has been updated to exclusively use SCOS (SIG-CoreOS) as the base operating system. All references to the previous Fedora CoreOS (FCOS) have been removed.
+*   **Default Container Runtime Changed to `crun` on Upgrade (OKD-294):** For clusters upgrading to version 4.20, the default container runtime will now be `crun`. The previous override that retained `runc` during upgrades has been removed to align with the new default. User-defined runtime configurations will be preserved.
+
+### Virtualization Enhancements
+
+*   **Secure Boot Enabled for vSphere (OKD-279):** Secure Boot is now enabled by default for OKD deployments on vSphere, enhancing the security posture of virtualized clusters.
+
+### Bare Metal Provisioning (Ironic & Metal3)
+
+*   **Component Stability Fixes (OKD-306, OKD-297, OKD-283, OKD-304, OKD-295):** A series of improvements have been made to enhance the reliability of bare metal deployments. These updates resolve issues that caused `ironic-proxy` and `metal3` pods to crash, fix broken `ironic-agent-image` and `ironic-image` containers, and correct a missing `pyinotify` module that previously caused `metal3` deployment failures.

--- a/blog/2026/01-26-okd-4.21-release-notes.md
+++ b/blog/2026/01-26-okd-4.21-release-notes.md
@@ -8,6 +8,13 @@ date: 2026-01-26
 
 This release introduces significant updates to storage management, security hardening via read-only filesystems, and the promotion of several Tech Preview features to General Availability (GA). [4.21.0-okd-scos.0](https://amd64.origin.releases.ci.openshift.org/releasestream/4-scos-stable/release/4.21.0-okd-scos.0) is the source of this information.
 
+<!-- truncate -->
+
+:::info
+These release notes are non-exhaustive. OKD contains many component project and you can ue the CI produced notes to fully review
+all the changes that have been made. Let us know if you see any errors or large omissions!
+:::
+
 ---
 
 ### Storage

--- a/blog/2026/01-26-okd-4.21-release-notes.md
+++ b/blog/2026/01-26-okd-4.21-release-notes.md
@@ -6,100 +6,72 @@ date: 2026-01-26
 
 ## Release Notes: 4.21.0-okd-scos.0
 
-This release includes updates across various components, introducing new features, managing feature gates, and resolving numerous bugs to enhance stability and functionality. [4.21.0-okd-scos.0](https://amd64.origin.releases.ci.openshift.org/releasestream/4-scos-stable/release/4.21.0-okd-scos.0) is the source of this information. Key highlights include the promotion of Dynamic Resource Allocation (DRA) to General Availability, the adoption of SCOS as the standard base operating system, and a shift toward a more modular testing and monitoring architecture.
-
-## Origin Community Distribution (OKD) Specifics
-
-### Platform and Installer Updates
-
-* **SCOS as Standard:** The installer now exclusively uses SCOS (SIG-CoreOS) as the base operating system. All references to Fedora CoreOS (FCOS) have been removed.
-* **Default Runtime Change:** Clusters upgrading to version 4.20 and beyond will now use `crun` as the default container runtime. User-defined runtime configurations are preserved during this transition.
-* **Secure Boot for vSphere:** Secure Boot is now enabled by default for OKD deployments on vSphere.
+This release introduces significant updates to storage management, security hardening via read-only filesystems, and the promotion of several Tech Preview features to General Availability (GA). [4.21.0-okd-scos.0](https://amd64.origin.releases.ci.openshift.org/releasestream/4-scos-stable/release/4.21.0-okd-scos.0) is the source of this information.
 
 ---
 
-## Node and Workloads
+### Storage
 
-### Dynamic Resource Allocation (DRA) - GA
+* **Azure File Volume Cloning (GA):** Cloning Azure File volumes by referencing a source PersistentVolumeClaim (PVC) is now Generally Available, supporting both SMB and NFS protocols ([STOR-1945](https://issues.redhat.com/browse/STOR-1945)).
+* **VolumeAttributesClass (GA):** Admins can now define and modify storage attributes (like IOPS or throughput) on provisioned volumes after creation ([STOR-2533](https://issues.redhat.com/browse/STOR-2533)).
+* **Mutable CSI Node Allocatable Property (Tech Preview):** Allows the number of attachable volumes per node to be dynamically updated based on node capacity changes (e.g., adding a new network interface on AWS) ([STOR-2627](https://issues.redhat.com/browse/STOR-2627)).
+* **vSphere with Bare Metal Nodes (Tech Preview):** Environments can now include bare metal nodes, requiring the vSphere CSI driver to be disabled to avoid a degraded state ([STOR-2620](https://issues.redhat.com/browse/STOR-2620), [STOR-2634](https://issues.redhat.com/browse/STOR-2634)).
+* **API and Diagnostics:**
+* Volume Group Snapshots API updated to `v1beta2`; `v1beta1` is removed ([STOR-2534](https://issues.redhat.com/browse/STOR-2534)).
+* `must-gather` now collects `VolumeAttributesClass`, `VolumeGroupSnapshotClass`, and `VolumeGroupSnapshotContent` resources ([STOR-2691](https://issues.redhat.com/browse/STOR-2691), [STOR-2692](https://issues.redhat.com/browse/STOR-2692)).
 
-DRA has been promoted to General Availability. This feature provides a more flexible framework for managing hardware resources like GPUs.
 
-* The `v1` DRA API is now the standard; alpha/beta APIs have been removed.
-* **Prioritized Alternatives:** Pods can now request a prioritized list of device options, allowing for fallback choices if primary resources are unavailable.
-
-### Security and Resource Management
-
-* **User Namespaces (GA):** Linux user namespaces are now GA, providing enhanced isolation by remapping user and group IDs inside containers.
-* **Automatic System Resource Reservation:** The `autoSizingReserved` feature in `KubeletConfig` is now enabled by default, automatically calculating optimal CPU and memory reservations for system components.
-* **Image Verification (GA):** The default `openshift` ClusterImagePolicy and `SigstoreImageVerificationPKI` are now GA, allowing clusters to validate release payloads and use custom PKI for image signatures out of the box.
-
----
-
-## Storage
-
-### Volume Management
-
-* **VolumeAttributesClass (VAC) - GA:** Users can now modify volume attributes like IOPS and throughput after creation for supported CSI drivers.
-* **Azure File Volume Cloning (GA):** Supports cloning for both SMB and NFS protocols.
-* **VolumeGroup Snapshots:** The API has been updated to `v1beta2`.
-
-### Platform Compatibility
-
-* **vSphere Bare-Metal Support (Tech Preview):** The vSphere CSI driver now automatically disables itself on bare-metal nodes within hybrid vSphere clusters to prevent degraded states.
-* **oVirt Removal:** The oVirt CSI driver and operator have been removed as the platform is no longer supported.
+* **Security Hardening:** CSI driver containers and the Cluster Storage Operator now utilize **read-only root filesystems** and enhanced **Network Policies** ([STOR-2340](https://issues.redhat.com/browse/STOR-2340), [STOR-2560](https://issues.redhat.com/browse/STOR-2560)).
+* **Driver Updates:** AWS EBS and EFS CSI drivers migrated to AWS SDK v2 ([STOR-2538](https://issues.redhat.com/browse/STOR-2538)). The **oVirt CSI Driver** has been removed ([STOR-2297](https://issues.redhat.com/browse/STOR-2297)).
 
 ---
 
-## Networking
+### Platform and Installation
 
-### Core Networking Enhancements
+#### vSphere Enhancements
 
-* **Static IP/MAC for VMs (GA):** Assigning static IP and MAC addresses to Virtual Machines on secondary Layer 2 User-Defined Networks (UDNs) is now GA. This includes active MAC conflict detection to prevent network collisions.
-* **IPv6/Dual-Stack Installation:** A new feature gate enables IPv6 and dual-stack configurations during initial cluster setup.
+* **vSphere 7.x Deprecation:** Support for vSphere 7.x is entering deprecation. Non-blocking warnings will appear during IPI installations unless an extended support contract is detected ([SPLAT-2347](https://issues.redhat.com/browse/SPLAT-2347), [SPLAT-2511](https://issues.redhat.com/browse/SPLAT-2511)).
+* **Secure Boot:** The installer no longer disables Secure Boot if it is enabled in the underlying OVA template ([OKD-279](https://issues.redhat.com/browse/OKD-279)).
 
-### Ingress and DNS
+#### AWS and GCP Updates
 
-* **Label Propagation:** Labels can now be synchronized from an Ingress resource to its generated Route using the `route.openshift.io/reconcile-labels: "true"` annotation.
-* **Optional VIPs:** Users can now disable internal DNS records when utilizing external load balancers that manage their own DNS.
+* **AWS Network Load Balancers (NLB):** Support added for NLBs with associated Security Groups ([SPLAT-2137](https://issues.redhat.com/browse/SPLAT-2137)).
+* **AWS EC2 Dedicated Hosts (Tech Preview):** Support is being introduced for provisioning nodes on managed or BYO dedicated hosts ([SPLAT-2193](https://issues.redhat.com/browse/SPLAT-2193)).
+* **GCP Spot VMs:** Users can now create worker nodes using GCP Spot VMs by setting `provisioningModel: "Spot"` ([OCPCLOUD-3173](https://issues.redhat.com/browse/OCPCLOUD-3173)).
+* **GCP Private Service Connect:** Support added for private connections to Google APIs, including private DNS zone creation ([CORS-4258](https://issues.redhat.com/browse/CORS-4258)). Legacy custom endpoints have been removed ([CORS-4281](https://issues.redhat.com/browse/CORS-4281)).
 
----
+#### Agent-based Installer
 
-## Installer and Cloud Provider Updates
-
-### AWS Improvements
-
-* **EC2 Dedicated Hosts:** OpenShift now supports deployment on AWS Dedicated Hosts for both platform-provisioned and BYOH (Bring Your Own Host) scenarios.
-* **Confidential VMs:** Support for AMD SEV-SNP confidential computing is now available for both control plane and compute nodes.
-
-### GCP and Azure
-
-* **GCP Spot VMs:** Worker nodes can now be created using GCP Spot VMs by setting `provisioningModel: "Spot"` in the `GCPMachineProviderSpec`.
-* **Azure Marketplace Images:** The installer now defaults to using pre-existing RHCOS images from the Azure Marketplace to speed up deployment.
+* **Disconnected Environments:** Introduction of the `InternalReleaseImage` (IRI) API to manage local registries on nodes for installations without external registries ([AGENT-1282](https://issues.redhat.com/browse/AGENT-1282), [AGENT-1330](https://issues.redhat.com/browse/AGENT-1330)).
+* **Offline OLM:** Facilitates operator installation in offline environments via the `agent-olm-operators` ConfigMap ([AGENT-1248](https://issues.redhat.com/browse/AGENT-1248)).
 
 ---
 
-## Management and Observability
+### Networking
 
-### Console and UI
-
-* **Developer Perspective Deprecation:** Monitoring views (Dashboards, Targets) have been integrated into the Admin Perspective under the "Observe" section.
-* **OLMv1 Integration:** The Console now supports the new OLMv1 catalog (Tech Preview), including channel and version selection for extensions.
-
-### Monitoring and Diagnostics
-
-* **CRD-Based Configuration:** A new feature-gated capability allows configuring the monitoring stack via CRDs instead of ConfigMaps, providing faster API validation.
-* **`must-gather` Improvements:** The tool now automatically inspects its own temporary namespace if a pod fails, aiding in self-diagnostics.
-* **Unified Service Mesh Diagnostics:** `istio-must-gather` has been consolidated into the primary OpenShift `must-gather` tool.
+* **Static IP and MAC for VMs (GA):** Persistent network identity is now supported for Virtual Machines on secondary Layer 2 User-Defined Networks (UDNs) ([CORENET-6005](https://issues.redhat.com/browse/CORENET-6005)).
+* **MAC Conflict Detection:** OVN-Kubernetes now automatically prevents duplicate MAC address assignments ([CORENET-6160](https://issues.redhat.com/browse/CORENET-6160)).
+* **Gateway API:** Upgraded to v1.3.0. Supports the Gateway API Inference Extension (GIE) for RHOAI workloads ([NE-2161](https://issues.redhat.com/browse/NE-2161), [NE-2050](https://issues.redhat.com/browse/NE-2050)).
+* **Core Components:** CoreDNS rebased to v1.13.1. Networking components updated to align with Kubernetes 1.34 ([NE-2194](https://issues.redhat.com/browse/NE-2194)).
 
 ---
 
-## Over the Air (OTA) Updates
+### Node and Machine Management
 
-* **Upgrade Recommendations:** The `oc adm upgrade recommend` command is now GA and enabled by default.
-* **Upgrade Stability:** Improved accuracy for the `Progressing` status, ensuring transient events like node reboots do not trigger false state changes during cluster updates.
+* **Dynamic Resource Allocation (DRA) (GA):** The `v1` DRA API is now standard and enabled by default ([OCPNODE-3779](https://issues.redhat.com/browse/OCPNODE-3779)).
+* **Machine Config Operator (MCO):**
+* **Dual OS Stream (Tech Preview):** Allows different machine pools to use different OS versions (e.g., RHEL 9 and 10) in the same cluster ([MCO-1927](https://issues.redhat.com/browse/MCO-1927)).
+* **Boot Image Skew Enforcement (Tech Preview):** Manages boot image versions across nodes to prevent configuration drift ([MCO-1962](https://issues.redhat.com/browse/MCO-1962)).
+
+
+* **Resource Reservations:** `autoSizingReserved` in `KubeletConfig` is now enabled by default for new clusters to optimize system resource reservation ([OCPNODE-3719](https://issues.redhat.com/browse/OCPNODE-3719)).
+* **Container Runtime:** OKD clusters now default to the `crun` container runtime; the temporary `runc` override has been removed ([OKD-294](https://issues.redhat.com/browse/OKD-294)).
 
 ---
 
-## Known Issues
+### Operator Lifecycle Manager (OLM) and Console
 
-* **CustomNoUpgrade:** Enabling the `CustomNoUpgrade` feature gate may cause the `network` and `olm` Cluster Operators to enter a degraded state.
+* **OLMv1 Promotions:** `SingleNamespace` and `OwnNamespace` install modes, and the Webhook Provider, are now **Generally Available** ([OPRUN-4131](https://issues.redhat.com/browse/OPRUN-4131), [OPRUN-4156](https://issues.redhat.com/browse/OPRUN-4156)).
+* **Console Modernization:** * Developer monitoring views (Dashboards, Targets) are now integrated into the **Admin Perspective** ([OU-1130](https://issues.redhat.com/browse/OU-1130)).
+* List pages have been updated to the new `DataView` component for better performance.
+* The Monaco Code Editor now supports theme and font size customization.


### PR DESCRIPTION
Generated release notes using source [4.21.0-okd-scos.0](https://amd64.origin.releases.ci.openshift.org/releasestream/4-scos-stable/release/4.21.0-okd-scos.0)