### PR TITLE
Add homepage patch support notice

### DIFF
--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -1,0 +1,14 @@
+.patchSupport {
+  background: var(--ifm-color-emphasis-100);
+  border-block: 1px solid var(--ifm-color-emphasis-300);
+  padding-block: 2rem;
+
+  h2 {
+    margin-bottom: 0.5rem;
+  }
+
+  p {
+    font-size: 1.05rem;
+    max-width: 760px;
+  }
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,16 +13,40 @@ function HomepageHeader() {
  
 }
 
+function PatchSupportNotice() {
+  return (
+    <section className={styles.patchSupport} aria-labelledby="patch-support-title">
+      <div className="container">
+        <Heading as="h2" id="patch-support-title">
+          Patch Support
+        </Heading>
+        <p>
+          OKD publishes community patch releases through the stable update
+          channel after release verification passes. Not every patch number is
+          produced, so use the cluster update graph and the latest stable OKD
+          release when planning upgrades.
+        </p>
+        <a
+          className="button button--primary"
+          href="https://docs.okd.io/latest/updating/index.html">
+          Review OKD update guidance
+        </a>
+      </div>
+    </section>
+  );
+}
+
 export default function Home(): JSX.Element {
   return (
     <Layout
       title={`Kubernetes at Scale on any Infrastructure`}
       description="Bringing together 100+ components to provide comprehensive
-       tooling for administrators and developers, we've made choices so you 
-       don't have to. Deploy in-cloud or on-prem and join a community 
+       tooling for administrators and developers, we've made choices so you
+       don't have to. Deploy in-cloud or on-prem and join a community
        embracing the latest in cloud emerging technologies.">
       <HomepageHero />
       <main>
+        <PatchSupportNotice />
         <HomepageSoWhatIsOKD/>
         <HomepageFeatures />
         <HomagepageInsideOKD />


### PR DESCRIPTION
## Problem
The homepage does not currently surface OKD patch support guidance, so users have to infer update behavior from release/update docs.

## Root cause
The site has release notes and update docs, but no prominent homepage notice that explains how OKD patch releases are consumed.

## Approach
- Added a homepage `PatchSupportNotice` immediately below the hero.
- Kept it as a full-width Docusaurus section using existing theme tokens.
- Linked the call to action to the official OKD update guidance.
- Wording stays conservative: OKD publishes community patch releases through the stable update channel after verification passes, and users should use the update graph/latest stable release instead of assuming every patch number exists.

## Security review
This is a content-only homepage change. It does not add scripts, dependencies, credentials, tracking, or runtime data access. The only added outbound link points to official OKD documentation.

## Verification
- `npm ci` -> success; existing audit/deprecation warnings remain in the lockfile dependency tree
- `npm run build` -> success; existing Docusaurus/Sass warnings remain
- `git diff --check` -> passed, with Windows line-ending warnings only

Note: `npm run typecheck` currently fails on pre-existing `Cannot find namespace 'JSX'` errors across existing components (`HomepageFeatures`, `HomepageHero`, `HomepageInsideOKD`, `HomepageSoWhatIsOKD`, `OKDLogo`, and `src/pages/index.tsx`). This PR does not introduce that repo-wide TypeScript config issue.

Fixes #113